### PR TITLE
Replace :: in ruby constants for tags values with allowed symbols

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -464,18 +464,22 @@ class Statsd
 
   def send_stats(stat, delta, type, sample_rate=1, tags: {})
     if sample_rate == 1 or rand < sample_rate
-      # Replace Ruby module scoping with '.' and reserved chars (: | @) with underscores.
-      stat = stat.to_s.gsub('::', delimiter).tr(':|@', '_')
+      stat = sanitize(stat)
       rate = "|@#{sample_rate}" unless sample_rate == 1
       parsed_tags =
         if tags.empty?
           ""
         else
-          "," + tags.map {|key, value| "#{key}=#{value}" }.join(",")
+          "," + tags.map {|key, value| "#{key}=#{sanitize(value)}" }.join(",")
         end
 
       send_to_socket "#{prefix}#{stat}#{postfix}#{parsed_tags}:#{delta}|#{type}#{rate}"
     end
+  end
+
+  def sanitize(value)
+    # Replace Ruby module scoping with '.' and reserved chars (: | @) with underscores.
+    value.to_s.gsub('::', delimiter).tr(':|@', '_')
   end
 
   def socket

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -70,12 +70,12 @@ describe Statsd do
     end
   end
 
-  describe "#delimiter" do 
+  describe "#delimiter" do
     it "should set delimiter" do
       @statsd.delimiter = "-"
       @statsd.delimiter.must_equal "-"
     end
-    
+
     it "should set default to period if not given a value" do
       @statsd.delimiter = nil
       @statsd.delimiter.must_equal "."
@@ -376,6 +376,27 @@ describe Statsd do
     it "should replace statsd reserved chars in the stat name" do
       @statsd.increment('ray@hostname.blah|blah.blah:blah', 1)
       @socket.recv.must_equal ['ray_hostname.blah_blah.blah_blah:1|c']
+    end
+  end
+
+  describe "tags values" do
+    class Statsd::SomeClass; end
+    class Statsd::SomeWorker; end
+
+    it "should replace ruby constant delimeter with graphite package name" do
+      @statsd.increment(Statsd::SomeClass, 1, tags: { worker: Statsd::SomeWorker })
+      @socket.recv.must_equal ['Statsd.SomeClass,worker=Statsd.SomeWorker:1|c']
+    end
+
+    describe "custom delimiter" do
+      before do
+        @statsd.delimiter = "-"
+      end
+
+      it "should replace ruby constant delimiter with custom delimiter" do
+        @statsd.increment(Statsd::SomeClass, 1, tags: { worker: Statsd::SomeWorker })
+        @socket.recv.must_equal ['Statsd-SomeClass,worker=Statsd-SomeWorker:1|c']
+      end
     end
   end
 


### PR DESCRIPTION
We are unable at the moment to collects stats for sidekiq workers nested under ruby modules, because they have `::` in their names.
```
2017-09-28T10:52:40Z E! Error: splitting '|', Unable to parse metric: smartly.pena.sidekiq.perform,worker=Priceline::PriceQueryWorker:426|ms
2017-09-28T10:52:40Z E! Error: splitting '|', Unable to parse metric: smartly.pena.price_query_worker_performed,product_catalog=#<ProductCatalog:0x00007efcc005a2d0>,type=Priceline:1|c
```

https://www.flowdock.com/app/smartly/dpa/threads/2FEOep9UfMMNhsgTirszLRQ9NvJ